### PR TITLE
Fix salesOrder being overwritten and therefore creating wrong odoo records

### DIFF
--- a/pkg/exoscale/dbaas.go
+++ b/pkg/exoscale/dbaas.go
@@ -209,9 +209,10 @@ func (ds *DBaaS) AggregateDBaaS(ctx context.Context, exoscaleDBaaS []*egoscale.D
 
 			itemGroup := fmt.Sprintf("APPUiO Managed - Zone: %s / Namespace: %s", ds.clusterId, dbaasDetail.Namespace)
 			instanceId := fmt.Sprintf("%s/%s", dbaasDetail.Zone, dbaasDetail.DBName)
-			if ds.salesOrder == "" {
+			salesOrder := ds.salesOrder
+			if salesOrder == "" {
 				itemGroup = fmt.Sprintf("APPUiO Cloud - Zone: %s / Namespace: %s", ds.clusterId, dbaasDetail.Namespace)
-				ds.salesOrder, err = controlAPI.GetSalesOrder(ctx, ds.controlApiClient, dbaasDetail.Organization)
+				salesOrder, err = controlAPI.GetSalesOrder(ctx, ds.controlApiClient, dbaasDetail.Organization)
 				if err != nil {
 					logger.Error(err, "Unable to sync DBaaS, cannot get salesOrder", "namespace", dbaasDetail.Namespace)
 					continue
@@ -223,7 +224,7 @@ func (ds *DBaaS) AggregateDBaaS(ctx context.Context, exoscaleDBaaS []*egoscale.D
 				InstanceID:           instanceId,
 				ItemDescription:      "Exoscale DBaaS " + dbaasTypes[*dbaasUsage.Type],
 				ItemGroupDescription: itemGroup,
-				SalesOrder:           ds.salesOrder,
+				SalesOrder:           salesOrder,
 				UnitID:               ds.uomMapping[odoo.InstanceHour],
 				ConsumedUnits:        1,
 				TimeRange: odoo.TimeRange{

--- a/pkg/exoscale/objectstorage.go
+++ b/pkg/exoscale/objectstorage.go
@@ -112,9 +112,10 @@ func (o *ObjectStorage) getOdooMeteredBillingRecords(ctx context.Context, sosBuc
 
 			itemGroup := fmt.Sprintf("APPUiO Managed - Zone: %s / Namespace: %s", o.clusterId, bucketDetail.Namespace)
 			instanceId := fmt.Sprintf("%s/%s", bucketDetail.Zone, bucketDetail.BucketName)
-			if o.salesOrder == "" {
+			salesOrder := o.salesOrder
+			if salesOrder == "" {
 				itemGroup = fmt.Sprintf("APPUiO Cloud - Zone: %s / Namespace: %s", o.clusterId, bucketDetail.Namespace)
-				o.salesOrder, err = controlAPI.GetSalesOrder(ctx, o.controlApiClient, bucketDetail.Organization)
+				salesOrder, err = controlAPI.GetSalesOrder(ctx, o.controlApiClient, bucketDetail.Organization)
 				if err != nil {
 					logger.Error(err, "unable to sync bucket", "namespace", bucketDetail.Namespace)
 					continue
@@ -126,7 +127,7 @@ func (o *ObjectStorage) getOdooMeteredBillingRecords(ctx context.Context, sosBuc
 				InstanceID:           instanceId,
 				ItemDescription:      "AppCat Exoscale ObjectStorage",
 				ItemGroupDescription: itemGroup,
-				SalesOrder:           o.salesOrder,
+				SalesOrder:           salesOrder,
 				UnitID:               o.uomMapping[odoo.GBDay],
 				ConsumedUnits:        value,
 				TimeRange: odoo.TimeRange{


### PR DESCRIPTION
This PR fixes a bug, where the salesOrder in the object is overwritten and results in wrong odoo records for the following records.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
