### PR TITLE
Adjust instanceID for objectStorage to ensure uniqueness

### DIFF
--- a/pkg/cloudscale/objectstorage.go
+++ b/pkg/cloudscale/objectstorage.go
@@ -137,7 +137,7 @@ func (o *ObjectStorage) createOdooRecord(bucketMetricsData cloudscale.BucketMetr
 	return []odoo.OdooMeteredBillingRecord{
 		{
 			ProductID:            productIdStorage,
-			InstanceID:           instanceId,
+			InstanceID:           instanceId + "/storage",
 			ItemDescription:      bucketMetricsData.Subject.BucketName,
 			ItemGroupDescription: itemGroup,
 			SalesOrder:           salesOrder,
@@ -150,7 +150,7 @@ func (o *ObjectStorage) createOdooRecord(bucketMetricsData cloudscale.BucketMetr
 		},
 		{
 			ProductID:            productIdTrafficOut,
-			InstanceID:           instanceId,
+			InstanceID:           instanceId + "/trafficout",
 			ItemDescription:      bucketMetricsData.Subject.BucketName,
 			ItemGroupDescription: itemGroup,
 			SalesOrder:           salesOrder,
@@ -163,7 +163,7 @@ func (o *ObjectStorage) createOdooRecord(bucketMetricsData cloudscale.BucketMetr
 		},
 		{
 			ProductID:            productIdQueryRequests,
-			InstanceID:           instanceId,
+			InstanceID:           instanceId + "/requests",
 			ItemDescription:      bucketMetricsData.Subject.BucketName,
 			ItemGroupDescription: itemGroup,
 			SalesOrder:           salesOrder,

--- a/pkg/exoscale/objectstorage.go
+++ b/pkg/exoscale/objectstorage.go
@@ -126,7 +126,7 @@ func (o *ObjectStorage) getOdooMeteredBillingRecords(ctx context.Context, sosBuc
 
 			o := odoo.OdooMeteredBillingRecord{
 				ProductID:            productIdStorage,
-				InstanceID:           instanceId,
+				InstanceID:           instanceId + "/storage",
 				ItemDescription:      bucketDetail.BucketName,
 				ItemGroupDescription: itemGroup,
 				SalesOrder:           salesOrder,


### PR DESCRIPTION
the instanceID must be unique in a single SO. Since objectstorage is billed on multiple metrics (storage, requests and trafficout) we need to adjust the instanceID to ensure it's unique for all metrics.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
