### PR TITLE
Adjust metered billing id for exoscale

### DIFF
--- a/pkg/exoscale/dbaas.go
+++ b/pkg/exoscale/dbaas.go
@@ -222,7 +222,7 @@ func (ds *DBaaS) AggregateDBaaS(ctx context.Context, exoscaleDBaaS []*egoscale.D
 			}
 
 			o := odoo.OdooMeteredBillingRecord{
-				ProductID:            productIdPrefix + fmt.Sprintf("-%s-%s", *dbaasUsage.Type, *dbaasUsage.Plan),
+				ProductID:            productIdPrefix + fmt.Sprintf("-v2-%s-%s", *dbaasUsage.Type, *dbaasUsage.Plan),
 				InstanceID:           instanceId,
 				ItemDescription:      dbaasDetail.DBName,
 				ItemGroupDescription: itemGroup,

--- a/pkg/exoscale/dbaas_test.go
+++ b/pkg/exoscale/dbaas_test.go
@@ -19,7 +19,7 @@ func TestDBaaS_aggregatedDBaaS(t *testing.T) {
 
 	now := time.Now().In(location)
 	record1 := odoo.OdooMeteredBillingRecord{
-		ProductID:            "appcat-exoscale-pg-hobbyist-2",
+		ProductID:            "appcat-exoscale-v2-pg-hobbyist-2",
 		InstanceID:           "ch-gva-2/postgres-abc",
 		ItemDescription:      "postgres-abc",
 		ItemGroupDescription: "APPUiO Managed - Cluster: c-test1 / Namespace: vshn-xyz",
@@ -32,7 +32,7 @@ func TestDBaaS_aggregatedDBaaS(t *testing.T) {
 		},
 	}
 	record2 := odoo.OdooMeteredBillingRecord{
-		ProductID:            "appcat-exoscale-pg-business-128",
+		ProductID:            "appcat-exoscale-v2-pg-business-128",
 		InstanceID:           "ch-gva-2/postgres-def",
 		ItemDescription:      "postgres-def",
 		ItemGroupDescription: "APPUiO Managed - Cluster: c-test1 / Namespace: vshn-uvw",


### PR DESCRIPTION
We need to adjust the metered billing id for exoscale, as the different plans where indivdual products instead of variants.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
