### PR TITLE
Fixed logic to bill S3 storage 

### DIFF
--- a/pkg/cloudscale/objectstorage.go
+++ b/pkg/cloudscale/objectstorage.go
@@ -132,9 +132,14 @@ func (o *ObjectStorage) GetMetrics(ctx context.Context, billingDate time.Time) (
 		salesOrder := o.salesOrder
 		if salesOrder == "" {
 			appuioManaged = false
+			if bucket.Organization == "" {
+				// in cases that our VSHN services are using buckets, then Organization is not set, we must default it to "vshn"
+				// we can't set it in cluster as for customers as then we might run into scheduling issues
+				bucket.Organization = "vshn"
+			}
 			salesOrder, err = controlAPI.GetSalesOrder(ctx, o.controlApiClient, bucket.Organization)
 			if err != nil {
-				logger.Error(err, "unable to sync bucket", "namespace", bucket)
+				logger.Error(err, "unable to sync bucket", "namespace", bucket, "reason", err)
 				continue
 			}
 		}

--- a/pkg/cloudscale/objectstorage.go
+++ b/pkg/cloudscale/objectstorage.go
@@ -114,17 +114,15 @@ func (o *ObjectStorage) GetMetrics(ctx context.Context, billingDate time.Time) (
 		return nil, err
 	}
 
-	for bucket := range bucketMap {
-		bucketName := bucketMap[bucket].BucketMetricsData.Subject.BucketName
-		if val, ok := buckets[bucketName]; ok {
-			bucketMap[bucket].Zone = val.Zone
+	for name, bucket := range bucketMap {
+		if val, ok := buckets[name]; ok {
+			bucket.Zone = val.Zone
 		}
 
 		// assign organisation to bucketMap
-		if val, ok := nsTenants[bucketMap[bucket].Namespace]; ok {
-			bucketMap[bucket].Organization = val
+		if val, ok := nsTenants[bucket.Namespace]; ok {
+			bucket.Organization = val
 		}
-
 	}
 
 	allRecords := make([]odoo.OdooMeteredBillingRecord, 0)

--- a/pkg/cmd/cloudscale.go
+++ b/pkg/cmd/cloudscale.go
@@ -123,7 +123,7 @@ func CloudscaleCmds(allMetrics map[string]map[string]prometheus.Counter) *cli.Co
 			wg.Add(1)
 			go func() {
 				for {
-					if time.Now().Hour() >= billingHour {
+					if true {
 
 						billingDate := time.Now().In(location)
 						if days != 0 {
@@ -136,21 +136,19 @@ func CloudscaleCmds(allMetrics map[string]map[string]prometheus.Counter) *cli.Co
 							logger.Error(err, "could not collect cloudscale bucket metrics")
 							wg.Done()
 						}
-
 						if len(metrics) == 0 {
 							logger.Info("No data to export to odoo", "date", billingDate)
 							time.Sleep(time.Hour)
 							continue
 						}
-
 						logger.Info("Exporting data to Odoo", "billingHour", billingHour, "date", billingDate)
 						err = odooClient.SendData(metrics)
 						if err != nil {
 							logger.Error(err, "could not export cloudscale bucket metrics")
 						}
-						time.Sleep(time.Hour * time.Duration(collectInterval))
+						time.Sleep(time.Hour * time.Duration(15))
 					}
-					time.Sleep(time.Hour)
+					time.Sleep(time.Minute * 1)
 				}
 			}()
 			wg.Wait()

--- a/pkg/cmd/cloudscale.go
+++ b/pkg/cmd/cloudscale.go
@@ -123,7 +123,7 @@ func CloudscaleCmds(allMetrics map[string]map[string]prometheus.Counter) *cli.Co
 			wg.Add(1)
 			go func() {
 				for {
-					if true {
+					if time.Now().Hour() >= billingHour {
 
 						billingDate := time.Now().In(location)
 						if days != 0 {
@@ -136,19 +136,21 @@ func CloudscaleCmds(allMetrics map[string]map[string]prometheus.Counter) *cli.Co
 							logger.Error(err, "could not collect cloudscale bucket metrics")
 							wg.Done()
 						}
+
 						if len(metrics) == 0 {
 							logger.Info("No data to export to odoo", "date", billingDate)
 							time.Sleep(time.Hour)
 							continue
 						}
+
 						logger.Info("Exporting data to Odoo", "billingHour", billingHour, "date", billingDate)
 						err = odooClient.SendData(metrics)
 						if err != nil {
 							logger.Error(err, "could not export cloudscale bucket metrics")
 						}
-						time.Sleep(time.Hour * time.Duration(15))
+						time.Sleep(time.Hour * time.Duration(collectInterval))
 					}
-					time.Sleep(time.Minute * 1)
+					time.Sleep(time.Hour)
 				}
 			}()
 			wg.Wait()

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	orgv1 "github.com/appuio/control-api/apis/organization/v1"
-	"github.com/vshn/billing-collector-cloudservices/pkg/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,7 +76,6 @@ func restConfig(kubeconfig string, url string, token string) (*rest.Config, erro
 }
 
 func FetchNamespaceWithOrganizationMap(ctx context.Context, k8sClient client.Client) (map[string]string, error) {
-	logger := log.Logger(ctx)
 
 	gvk := schema.GroupVersionKind{
 		Group:   "",
@@ -96,7 +94,6 @@ func FetchNamespaceWithOrganizationMap(ctx context.Context, k8sClient client.Cli
 	for _, ns := range list.Items {
 		orgLabel, ok := ns.GetLabels()[OrganizationLabel]
 		if !ok {
-			logger.Info("Organization label not found in namespace", "namespace", ns.GetName())
 			continue
 		}
 		namespaces[ns.GetName()] = orgLabel


### PR DESCRIPTION
Our Cloudscale exporter run into troubles when there were 2 or more buckets inside S3 endpoint. This problem caused in missing billing records for additional buckets.